### PR TITLE
Found discordgo's logging logic.

### DIFF
--- a/discord/discord.go
+++ b/discord/discord.go
@@ -126,6 +126,9 @@ func NewClient(config *config.Configuration, logger *zap.Logger) (DiscordClient,
 		return nil, err
 	}
 
+	// TODO: I still some code in discordgo using this so set it for now.
+	session.Debug = true
+	session.LogLevel = 3
 	newClient = client{session: session, logger: logger}
 
 	// Start up name resolution cache updater


### PR DESCRIPTION
Also found golangs Named return values implementation: https://tour.golang.org/basics/7.  Here, I thought discordgo was violating some rule somehow or that golang allowed returns with nothing... I thought that was odd... guess I should read the docs more or pay more attention to features I think are absolutely rubbish.